### PR TITLE
fix(msstyleEditorSharp): add support for improved DPI awareness on newer systems

### DIFF
--- a/msstyleEditorSharp/App.manifest
+++ b/msstyleEditorSharp/App.manifest
@@ -29,7 +29,9 @@
 
   <application xmlns="urn:schemas-microsoft-com:asm.v3">
     <windowsSettings>
-      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/pm</dpiAware>
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2, PerMonitor, System, unaware</dpiAwareness>
+      <gdiScaling xmlns="http://schemas.microsoft.com/SMI/2017/WindowsSettings">true</gdiScaling>
     </windowsSettings>
   </application>
   


### PR DESCRIPTION
# Problem 
>  fixed property values not persisting, set appl. DPI aware, working on issue #83
https://github.com/nptr/msstyleEditor/commit/f23db771ec9632c58a81a49d3ac3cd1c4f4d0695#diff-ba5ff7872fe40f60eae65ab65149696947047a9dc0420273d6b363aa0778d538

The above changes added *very* simple DPI awareness which was introduced with Windows Vista. Because no other awareness was specified, all later systems will use this DPI awareness which scales GUIs as blurry bitmaps and will not update scaling when moved to a monitor with a different DPI.

# Solution
- Change `<dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>` to `<dpiAware "http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/pm</dpiAware>` for the best legacy support.
  - Windows 8.1 will use its simple per-monitor DPI awareness. Application UIs will not bitmap-stretch, but child windows and UI elements will not scale. Windows Vista, 7, and 8 will be aware of Primary display's DPI and its changes, but will use bitmap-stretching for scaling.
- Add `<dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2, PerMonitor, System, unaware</dpiAwareness>` .
  - Windows 10 (1703) and later will use an improved per-monitor DPI awareness. Top-level and child HWNDs are notified of DPI change. Includes automatic DPI scaling of Non-client area, Theme-drawn bitmaps in common controls (comctl32 V6), and Dialogs (CreateDialog).
- Add `<gdiScaling xmlns="http://schemas.microsoft.com/SMI/2017/WindowsSettings">true</gdiScaling>` to allow WinForm's GDI+ backend to be DPI-aware.

----

Because WinForms uses GDI+ to draw GUIs, we may need to enable GDI Scaling (only works on Windows 10 (1703) and later).

Since Windows Vista, `<dpiAware>true</dpiAware>` sets DPI awareness level to "system". According to the table under [Per-Monitor and Per-Monitor (V2) DPI Awareness](https://learn.microsoft.com/en-us/windows/win32/hidpi/high-dpi-desktop-application-development-on-windows#per-monitor-and-per-monitor-v2-dpi-awareness), system-level awareness means "All displays have the same DPI (the DPI of the primary display at the time the current user session was started)". The application will scale to the DPI of the Primary display. When the DPI is changed (whether it be that of the Primary display or because the window was moved to another display), Windows will scale the application via "bitmap-stretching", causing blurring.

Windows 8.1 introduced a (very simple) per-monitor DPI awareness level that could be set via `<dpiAware>per monitor</dpiAware>` or (allows pre-8.1 Windows to use system-awareness) `<dpiAware>true/pm</dpiAware>`.

Windows 10 (1607) introduced a new element, [dpiAwareness](https://learn.microsoft.com/en-us/windows/win32/sbscs/application-manifests#dpiawareness). When this element is present, the dpiAware element is ignored. The values allowed for this element were equivalent to dpiAware's values until Windows 10 (1703) added the value "PerMonitorV2".